### PR TITLE
Docker healtcheck using api key to prevent unauthorizzed access errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 7000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:7000/manifest.json || exit 1
+  CMD curl -f http://localhost:7000/manifest.json?api_key=${ADDON_API_KEY} || exit 1
 
 # Spuštění aplikace
 CMD ["node", "sktorrent-addon.js"]


### PR DESCRIPTION
There was error occuring in logs "🚫 Neautorizovaný přístup od ..." every 30 seconds. Use api key with healthcheck to prevent floading logs with irrelevant error messages.